### PR TITLE
Feat | Cria o arquivo .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+build/
+dist/
+coverage/
+.env*


### PR DESCRIPTION
## Causa do problema
A ausência de um arquivo .gitignore enquanto trabalhamos com um projeto versionado.

## Por que a alteração foi feita de tal maneira
É um arquivo básico, com as pastas e arquivos mais comumente usados em projetos no geral.

## Como a alteração resolve o problema encontrado
A criação do arquivo .gitignore evita que pastas e arquivos indesejados sejam versionados. Por exemplo, a pasta node_modules contem todas as dependências do projeto e subir ela para o repositório remoto, poderia deixa-lo muito pesado desnecessariamente.
Outro exemplo são os arquivos .env, que geralmente contem dados sensíveis e que nunca devem ser enviados e/ou versionados.
