### PR TITLE
Fix | Corrige o arquivo docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,9 +15,9 @@ services:
       - main:/var/lib/mysql
       - ./db/:/docker-entrypoint-initdb.d/
     ports:
-      - 3305:3305
+      - 3305:3306
     healthcheck:
-      test: ["CMD", "mysqladmin" ,"ping", "-h", "localhost"]
+      test: [ "CMD", "mysqladmin", "ping", "-h", "localhost" ]
       timeout: 1s
       retries: 5
 
@@ -36,7 +36,7 @@ services:
     environment:
       WRITER_MYSQL_HOST: "mysql"
       WRITER_MYSQL_PASS: "root"
-      WRITER_MYSQL_PORT: "3305"
+      WRITER_MYSQL_PORT: "3306"
       WRITER_MYSQL_USER: "root"
       NODE_ENV: "development"
       PORT: "8081"
@@ -49,4 +49,3 @@ services:
 volumes:
   control-posts-node-modules:
   main:
-      


### PR DESCRIPTION
## Causa do problema
A porta do banco de dados e a porta do backend que acessa o banco de dados estavam incorretas. Ao invés de serem `3306`, estavam como `3305`.

## Por que a alteração foi feita de tal maneira
O MySQL, que é o nosso banco de dados, requer que ele rode na porta `3306`.

## Como a alteração resolve o problema encontrado
Ao alterar as portas de `3305` para `3306`, o MySQL consegue fazer as conexões corretamente.
