### PR TITLE
Fix | Corrige o arquivo schema.sql

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,16 +1,16 @@
 USE `main`;
 
+CREATE TABLE users (
+    id INT PRIMARY KEY AUTO_INCREMENT,
+    full_name VARCHAR(100),
+    user_email VARCHAR(100) NOT NULL,
+    user_password VARCHAR(200) NOT NULL
+);
+
 CREATE TABLE posts (
     id INT PRIMARY KEY AUTO_INCREMENT,
     author_id INT NOT NULL,
     post_text VARCHAR(200)
-);
-
-CREATE TABLE users (
-    id VARCHAR(100) PRIMARY KEY AUTO_INCREMENT,
-    full_name VARCHAR(100),
-    user_email VARCHAR(100) NOT NULL,
-    user_password VARCHAR(200) NOT NULL
 );
 
 ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';
@@ -18,4 +18,3 @@ ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';
 ALTER USER 'root' IDENTIFIED WITH mysql_native_password BY 'root';
 
 FLUSH PRIVILEGES;
-


### PR DESCRIPTION
## Causa do problema
A criação da tabela `users` não estava sendo feita. A propriedade `VARCHAR(100)` não deve ser usada com a `AUTO_INCREMENT`.
A ordem em que as tabelas são criadas também podem causar problemas, caso elas tenham relação.

## Por que a alteração foi feita de tal maneira
Nada de especial foi feito, apenas uma correção de sintaxe padrão e uma reordenação da ordem em que as tabelas são criadas para evitar problemas na criação de tabelas que estejam relacionadas.

## Como a alteração resolve o problema encontrado
Agora ambas tabelas, `users` e `posts` são criadas corretamente.
