### PR TITLE
Fix | Corrige problemas de CORS e porta padrão incorreta no arquivo app.js

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -5,7 +5,7 @@ const SwaggerUi = require('swagger-ui-express');
 const express = require('express');
 const { buildHandlers } = require('./modules');
 const { handlers } = buildHandlers();
-const port = Number(process.env.PORT || 8089)
+const port = Number(process.env.PORT || 8081)
 
 const app = express();
 

--- a/src/app.js
+++ b/src/app.js
@@ -10,7 +10,8 @@ const port = Number(process.env.PORT || 8081)
 const app = express();
 
 const whitelist = [
-  // TODO whitelist
+  // Remover essa url quando subir em produção
+  'http://localhost:8081'
 ]
 
 app.use(cors({

--- a/src/app.js
+++ b/src/app.js
@@ -16,6 +16,9 @@ const whitelist = [
 
 app.use(cors({
   origin: function (origin, callback) {
+    // Remover essa configuração quando subir em produção
+    if (!origin) return callback(null, true);
+
     const allowed = whitelist.indexOf(origin) !== -1
     if (allowed) return callback(null, true);
 


### PR DESCRIPTION
## Causa do problema
1. A porta padrão para a aplicação deveria ser `8081` mas estava como `8089`.
2. O CORS bloqueava as tentativas de acesso do servidor local de desenvolvimento.

## Por que a alteração foi feita de tal maneira
1. Sem essa alteração de porta, a aplicação poderia não rodar corretamente, caso não existisse um valor de `PORT` no arquivo de configuração de ambiente, `.env`.
2. Geralmente em ambientes de desenvolvimento, as requisições em alguns navegadores podem ter o header origin ausente.

## Como a alteração resolve o problema encontrado
1. Com a porta padrão corrigida, mesmo que nenhum valor para PORT seja configurado, o código garante que a porta da aplicação ainda seja a esperada inicialmente.
2. Com a alteração feita, o ambiente de desenvolvimento agora consegue requisitar a aplicação.
