### PR TITLE
Fix | Método commitTransaction na config do knex

### DIFF
--- a/src/modules/common/handlers/knex/knex.js
+++ b/src/modules/common/handlers/knex/knex.js
@@ -1,13 +1,13 @@
 'use strict'
 
 const knex = require('knex')({
-    client: 'mysql',
-    connection: {
-      host: process.env.WRITER_MYSQL_HOST,
-      user: process.env.WRITER_MYSQL_USER,
-      port: process.env.WRITER_MYSQL_PORT,
-      password: process.env.WRITER_MYSQL_PASS,
-      database: 'main'
+  client: 'mysql',
+  connection: {
+    host: process.env.WRITER_MYSQL_HOST,
+    user: process.env.WRITER_MYSQL_USER,
+    port: process.env.WRITER_MYSQL_PORT,
+    password: process.env.WRITER_MYSQL_PASS,
+    database: 'main'
   },
   pool: {
     min: 1,
@@ -17,12 +17,12 @@ const knex = require('knex')({
 
 const getTransaction = async () => {
 
-    const transaction = await knex.transaction()
+  const transaction = await knex.transaction()
 
-    return {transaction};
+  return { transaction };
 }
 
-const commitTransaction = ({ transaction }) => transaction.rollback();
+const commitTransaction = ({ transaction }) => transaction.commit();
 
 const rollbackTransaction = ({ transaction }) => transaction.rollback();
 


### PR DESCRIPTION
## Causa do problema
O uso incorreto de um método do knex. Ao invés de utilizar o `commit`, estava sendo utilizado o `rollback` para o método `commitTransaction`.

## Por que a alteração foi feita de tal maneira
Nada de especial foi feito, apenas a correção do método utilizado para que as alterações/criações possam ser feitas corretamente no banco de dados.

## Como a alteração resolve o problema encontrado
Com o método correto, o knex faz as alterações corretamente no banco de dados.
