### PR TITLE
Fix | Assincronicidade ao utilizar o método createUserService

### DIFF
--- a/src/modules/handlers/User/createUser.js
+++ b/src/modules/handlers/User/createUser.js
@@ -3,26 +3,26 @@ const httpStatusCodes = require('http-status-codes');
 const { httpErrorHandler } = require("../../common/handlers");
 const { createUserService } = require('../../services');
 
-const createUserHandler = (req, res, next) => {
-    try{
-        const {
-            user_email,
-            user_password,
-            full_name
-        } = req.body
+const createUserHandler = async (req, res, next) => {
+  try {
+    const {
+      user_email,
+      user_password,
+      full_name
+    } = req.body
 
-        const created_user = createUserService({
-            user_email,
-            user_password,
-            full_name
-        })
+    const created_user = await createUserService({
+      user_email,
+      user_password,
+      full_name
+    })
 
-        return res.status(httpStatusCodes.OK).send(created_user);
-    }catch(error){
-        return httpErrorHandler({ req, res, error })
-    }
+    return res.status(httpStatusCodes.OK).send(created_user);
+  } catch (error) {
+    return httpErrorHandler({ req, res, error })
+  }
 }
 
 module.exports = {
-    createUserHandler
+  createUserHandler
 }


### PR DESCRIPTION
## Causa do problema
Falta de `async/await` no handler `createUser`.

## Por que a alteração foi feita de tal maneira
Para que o handler `createUser` funcione como o esperado, ele deveria esperar a resposta do método `createUserService`.
Então um `async` foi adicionado ao handler e um `await` a variável `created_user`.

## Como a alteração resolve o problema encontrado
Com o `async/await` implementados de forma correta, o handler `createUser` espera corretamente a resposta do `createUserService`, corrigindo o problema de assincronicidade.
