### PR TITLE
Fix | Corrige o método createUserRepositories

### DIFF
--- a/src/modules/repositories/User/createUsersRepositories/createUsersRepositories.js
+++ b/src/modules/repositories/User/createUsersRepositories/createUsersRepositories.js
@@ -1,40 +1,38 @@
 const {
-    getTransaction,
-    commitTransaction,
-    rollbackTransaction
+  getTransaction,
+  commitTransaction,
+  rollbackTransaction
 } = require('../../../common/handlers')
 
 
 const createUserRepositories = async ({
-    user
+  user
 } = {}) => {
-    const { transaction } = await getTransaction();
+  const { transaction } = await getTransaction();
 
-    try {
-        const {
-            user_created
-        } = await transaction('users').insert(user)
-        
-        const has_response = Array.isArray(user_created) && user_created.length > 0;
+  try {
+    const user_created = await transaction('users').insert(user)
 
-        if (!has_response) {
-            return {
-                user_created: []
-            }
-        }
+    const has_response = Array.isArray(user_created) && user_created.length > 0;
 
-        await commitTransaction({transaction})
-
-        return {
-            user_created
-        }
-
-    } catch (err) {
-        rollbackTransaction({transaction})
-        throw new Error(err)
+    if (!has_response) {
+      return {
+        user_created: []
+      }
     }
+
+    await commitTransaction({ transaction })
+
+    return {
+      user_created
+    }
+
+  } catch (err) {
+    rollbackTransaction({ transaction })
+    throw new Error(err)
+  }
 }
 
 module.exports = {
-    createUserRepositories
+  createUserRepositories
 }


### PR DESCRIPTION
## Causa do problema
Desestruturação incorreta no método `createUserRepositories`.

## Por que a alteração foi feita de tal maneira
A alteração foi feita para que o resultado esperado fosse recebido corretamente. Com a desestruturação, o valor recebido sempre seria incorreto, impedindo o funcionamento da rota de criação de usuários.

## Como a alteração resolve o problema encontrado
Removendo a desestruturação, o valor recebido é o esperado, permitindo que usuários sejam criados corretamente.
