### PR TITLE
Fix | Corrige o método getUserRepositories

### DIFF
--- a/src/modules/handlers/User/listUsers.js
+++ b/src/modules/handlers/User/listUsers.js
@@ -15,7 +15,8 @@ const listUserHandler = async (req, res, next) => {
 
     const has_user_id = !!user_id && Number.isFinite(+user_id);
 
-    const user_response = has_user_id && getUserByIdService({ user_id });
+    const user_response = has_user_id && await getUserByIdService({ user_id });
+
 
     const users_response = !has_user_id && await getAllUsersService();
 

--- a/src/modules/repositories/User/getUserRepositories/getUserRepositories.js
+++ b/src/modules/repositories/User/getUserRepositories/getUserRepositories.js
@@ -1,31 +1,27 @@
-const { 
-    client
+const {
+  client
 } = require('../../../common/handlers')
 
 
 const getUserRepositories = async ({
-    user_id
+  user_id
 } = {}) => {
 
-    const {
-        response
-    } = await client('users').where({ id: user_id })
+  const response = await client('users').where({ id: user_id })
 
-    const has_response = Array.isArray(response) && response.length > 0;
+  const has_response = Array.isArray(response) && response.length > 0;
 
-    if(!has_response){
-        return {
-            users: []
-        }
+  if (!has_response) {
+    return {
+      users: []
     }
+  }
 
-    // return {
-    //     users: response
-    // }
-    return undefined;
-
+  return {
+    users: response
+  }
 }
 
 module.exports = {
-    getUserRepositories
+  getUserRepositories
 }


### PR DESCRIPTION
## Causa do problema
1. A falta de um `await` no handler `listUserHanlder`, na variável `user_response`.
2. O retorno do método getUserRepositories estava sendo sempre `undefined`, ao invés de retornar a busca de usuário.

## Por que a alteração foi feita de tal maneira
1. O `await` é obrigatório em funções assíncronas que usem `async`. Sem isso, o retorno é sempre uma `promise` ao invés do valor já esperado e tratado.
2. Com o retorno como estava antes, a busca nunca era enviada corretamente, sempre seria undefined, independente da busca.

## Como a alteração resolve o problema encontrado
1. Com a implementação do `await`, o código espera a resposta da busca, entregando o dado correto para a requisição.
2. Retornando o valor correto das buscas, a aplicação consegue entregar valores reais e corretos que permitem o funcionamento da aplicação.
