### PR TITLE
Fix | Corrige o método updateUserRepositories

### DIFF
--- a/src/modules/repositories/User/updateUserRepositories/updateUserRepositories.js
+++ b/src/modules/repositories/User/updateUserRepositories/updateUserRepositories.js
@@ -1,33 +1,34 @@
 const {
-    getTransaction,
-    commitTransaction,
-    rollbackTransaction
+  getTransaction,
+  commitTransaction,
+  rollbackTransaction
 } = require('../../../common/handlers')
 
 const updateUserRepositories = async ({
-    id,
-    user_email,
-    user_password,
-    full_name
+  id,
+  user_email,
+  user_password,
+  full_name
 }) => {
-    const { transaction } = await getTransaction();
+  const { transaction } = await getTransaction();
 
-    try {
+  try {
+    await transaction('users')
+      .where({ id })
+      .update({
+        user_email,
+        user_password,
+        full_name
+      })
 
-        await transaction('users').update({
-            user_email,
-            user_password,
-            full_name
-        })
+    await commitTransaction({ transaction })
 
-        await commitTransaction({ transaction })
-
-    } catch (err) {
-        rollbackTransaction({ transaction })
-        throw new Error(err)
-    }
+  } catch (err) {
+    rollbackTransaction({ transaction })
+    throw new Error(err)
+  }
 }
 
 module.exports = {
-    updateUserRepositories
+  updateUserRepositories
 }


### PR DESCRIPTION
## Causa do problema
O método `updateUserRepositories` estava atualizando todos os usuários do banco de dados, ao invés de apenas um especificado através do `id`.

## Por que a alteração foi feita de tal maneira
Pela documentação do knex, a alteração feita é a mais correta, especificando qual usuário deve ser atualizado.

## Como a alteração resolve o problema encontrado
Com a correção implementada, a aplicação atualizada corretamente apenas um usuário, que é especificado pelo ID enviado na requisição.
