### PR TITLE
Fix | Corrige o comportamento de criação de posts

### DIFF
--- a/src/modules/repositories/Post/createPostRepositories/createPostRepositories.js
+++ b/src/modules/repositories/Post/createPostRepositories/createPostRepositories.js
@@ -1,37 +1,38 @@
 const {
-    getTransaction,
-    commitTransaction,
-    rollbackTransaction
+  getTransaction,
+  commitTransaction,
+  rollbackTransaction
 } = require('../../../common/handlers')
 
 
 const createPostRepositories = async ({
-    post
+  post
 } = {}) => {
-    const { transaction } = await getTransaction();
+  const { transaction } = await getTransaction();
 
-    try {
-        const post_created = await transaction('posts').insert(post)
-        
-        const has_response = !Array.isArray(post_created) && post_created.length > 0;
+  try {
+    const post_created = await transaction('posts').insert(post)
 
-        if (!has_response) {
-            return {
-                post_created: []
-            }
-        }
+    const has_response = Array.isArray(post_created) && post_created.length > 0;
 
-
-        return {
-            post_created
-        }
-
-    } catch (err) {
-        rollbackTransaction({transaction})
-        throw new Error(err)
+    if (!has_response) {
+      return {
+        post_created: []
+      }
     }
+
+    await commitTransaction({ transaction })
+
+    return {
+      post_created
+    }
+
+  } catch (err) {
+    rollbackTransaction({ transaction })
+    throw new Error(err)
+  }
 }
 
 module.exports = {
-    createPostRepositories
+  createPostRepositories
 }


### PR DESCRIPTION
## Causa do problema
1. Utilização incorreta do operador `!` na logica que valida se a transaction do novo post foi criado.
2. Ausência da utilização do `commitTransaction` após a transaction ter sido criada e validada, impedindo que o novo post seja inserido no banco de dados.

## Por que a alteração foi feita de tal maneira
Nada de especial foi implementado para a correção. Apenas correção de uma logica incorreta e ausência de um método.

## Como a alteração resolve o problema encontrado
1. Removendo o operador incorreto, a validação funciona corretamente como esperado.
2. Ao utilizar o método `commitTransaction`, a transaction que foi criada e validada, é inserida no banco corretamente.
