### PR TITLE
Fix: Corrige o retorno dos posts de um usuário especifico

### DIFF
--- a/src/modules/repositories/Post/getPostByUserIdRepositories/getPostByUserIdRepositories.js
+++ b/src/modules/repositories/Post/getPostByUserIdRepositories/getPostByUserIdRepositories.js
@@ -1,29 +1,29 @@
-const { 
-    client
+const {
+  client
 } = require('../../../common/handlers')
 
 const getPostByUserIdRepositories = async ({
-    user_id
+  user_id
 } = {}) => {
 
-    const response = await client('posts').where({author_id: user_id})
+  const response = await client('posts').where({ author_id: user_id })
 
-    const has_response = Array.isArray(response) && response.length > 0;
+  const has_response = Array.isArray(response) && response.length > 0;
 
-    if(!has_response){
-        return {
-            posts: []
-        }
-    }
-
-    const posts = response.forEach(post => post);
-
+  if (!has_response) {
     return {
-        posts
+      posts: []
     }
+  }
+
+  const posts = response.map((post) => post);
+
+  return {
+    posts
+  }
 
 }
 
 module.exports = {
-    getPostByUserIdRepositories
+  getPostByUserIdRepositories
 }


### PR DESCRIPTION
## Causa do problema
Utilização do método forEach para retornar os posts de um usuário.

## Por que a alteração foi feita de tal maneira
Ao utilizar o método `map`, o array de posts é tratado com sucesso. O método `forEach` não retorna nada, diferente do `map`, que retorna um array novo, com a mesma quantidade de objetos que array original, mas fazendo o tratamento implementando na sua `callback`.

## Como a alteração resolve o problema encontrado
Ao retornar corretamente o array de posts tratados, a aplicação entrega o esperado para a requisição, diferente de antes, que apenas um array vazio era entregue, independentemente se a requisição estava correta ou não.
