### PR TITLE
Refactor | Atualiza a utilização da lib http-status-codes

### DIFF
--- a/src/modules/common/handlers/http-error-handler/http-error-handler.js
+++ b/src/modules/common/handlers/http-error-handler/http-error-handler.js
@@ -1,10 +1,10 @@
-const httpStatusCodes = require('http-status-codes');
+const { StatusCodes } = require('http-status-codes');
 const uuid = require('uuid');
 
 const httpErrorHandler = ({ req, res, error }) => {
 
-  const response_status_code = error.statusCode || httpStatusCodes.INTERNAL_SERVER_ERROR;
-  const is_internal = error.statusCode === httpStatusCodes.INTERNAL_SERVER_ERROR;
+  const response_status_code = error.statusCode || StatusCodes.INTERNAL_SERVER_ERROR;
+  const is_internal = error.statusCode === StatusCodes.INTERNAL_SERVER_ERROR;
   const error_id = uuid.v4();
 
   const response = {

--- a/src/modules/handlers/Posts/createPost.js
+++ b/src/modules/handlers/Posts/createPost.js
@@ -1,27 +1,27 @@
 'use strict'
 
-const httpStatusCodes = require('http-status-codes');
+const { StatusCodes } = require('http-status-codes');
 const { httpErrorHandler } = require("../../common/handlers");
 const { createPostService } = require('../../services');
 
-const createPostHandler = async(req, res, next) => {
-    try{
-        const {
-            post_text,
-            author_id
-        } = req.body
+const createPostHandler = async (req, res, next) => {
+  try {
+    const {
+      post_text,
+      author_id
+    } = req.body
 
-        const created_post = await createPostService({
-            post_text,
-            author_id
-        })
+    const created_post = await createPostService({
+      post_text,
+      author_id
+    })
 
-        return res.status(httpStatusCodes.OK).send(created_post);
-    }catch(error){
-        return httpErrorHandler({ req, res, error })
-    }
+    return res.status(StatusCodes.OK).send(created_post);
+  } catch (error) {
+    return httpErrorHandler({ req, res, error })
+  }
 }
 
 module.exports = {
-    createPostHandler
+  createPostHandler
 }

--- a/src/modules/handlers/Posts/deletePost.js
+++ b/src/modules/handlers/Posts/deletePost.js
@@ -1,28 +1,28 @@
 'use strict'
 
-const httpStatusCodes = require('http-status-codes');
+const { StatusCodes } = require('http-status-codes');
 const { httpErrorHandler } = require("../../common/handlers");
 const { deletePostService } = require('../../services');
 
 const deletePostHandler = async (req, res, next) => {
-    try{
+  try {
 
-        const {
-            post_id
-        } = req.query;
+    const {
+      post_id
+    } = req.query;
 
-        const {
-            deletedPost
-        } = await deletePostService({
-            post_id
-        })
+    const {
+      deletedPost
+    } = await deletePostService({
+      post_id
+    })
 
-        return res.status(httpStatusCodes.OK).send({deletedPost})
-    }catch(error){
-        return httpErrorHandler({ req, res, error })
-    }
+    return res.status(StatusCodes.OK).send({ deletedPost })
+  } catch (error) {
+    return httpErrorHandler({ req, res, error })
+  }
 }
 
 module.exports = {
-    deletePostHandler
+  deletePostHandler
 }

--- a/src/modules/handlers/Posts/listPost.js
+++ b/src/modules/handlers/Posts/listPost.js
@@ -1,29 +1,29 @@
 'use strict'
 
-const httpStatusCodes = require('http-status-codes');
+const { StatusCodes } = require('http-status-codes');
 const { httpErrorHandler } = require('../../common/handlers');
-const { 
-    getPostByUserIdService 
+const {
+  getPostByUserIdService
 } = require('../../services');
 
 const listPostHandler = async (req, res, next) => {
-    try{
-        const {
-            user_id
-        } = req.query;
-        
-        const {
-            posts
-        } = await getPostByUserIdService({
-            user_id
-        })
+  try {
+    const {
+      user_id
+    } = req.query;
 
-        return res.status(httpStatusCodes.OK).send({posts});
-    }catch(error){
-        return httpErrorHandler({ req, res, error })
-    }
+    const {
+      posts
+    } = await getPostByUserIdService({
+      user_id
+    })
+
+    return res.status(StatusCodes.OK).send({ posts });
+  } catch (error) {
+    return httpErrorHandler({ req, res, error })
+  }
 }
 
 module.exports = {
-    listPostHandler
+  listPostHandler
 }

--- a/src/modules/handlers/Posts/updatePost.js
+++ b/src/modules/handlers/Posts/updatePost.js
@@ -1,28 +1,28 @@
 'use strict'
-const httpStatusCodes = require('http-status-codes');
+const { StatusCodes } = require('http-status-codes');
 const { httpErrorHandler } = require("../../common/handlers");
 const { updatePostService } = require('../../services');
 
 const updatePostHandler = async (req, res, next) => {
-    try{
-        const {
-            id,
-            author_id,
-            post_text
-        } = req.body
+  try {
+    const {
+      id,
+      author_id,
+      post_text
+    } = req.body
 
-        const updated_post = await updatePostService({
-            id,
-            author_id,
-            post_text
-        })
+    const updated_post = await updatePostService({
+      id,
+      author_id,
+      post_text
+    })
 
-        return res.status(httpStatusCodes.OK).send(updated_post);
-    }catch(error){
-        return httpErrorHandler({ req, res, error })
-    }
+    return res.status(StatusCodes.OK).send(updated_post);
+  } catch (error) {
+    return httpErrorHandler({ req, res, error })
+  }
 }
 
 module.exports = {
-    updatePostHandler
+  updatePostHandler
 }

--- a/src/modules/handlers/User/createUser.js
+++ b/src/modules/handlers/User/createUser.js
@@ -1,5 +1,5 @@
 'use strict'
-const httpStatusCodes = require('http-status-codes');
+const { StatusCodes } = require('http-status-codes');
 const { httpErrorHandler } = require("../../common/handlers");
 const { createUserService } = require('../../services');
 
@@ -17,7 +17,7 @@ const createUserHandler = async (req, res, next) => {
       full_name
     })
 
-    return res.status(httpStatusCodes.OK).send(created_user);
+    return res.status(StatusCodes.OK).send(created_user);
   } catch (error) {
     return httpErrorHandler({ req, res, error })
   }

--- a/src/modules/handlers/User/deleteUser.js
+++ b/src/modules/handlers/User/deleteUser.js
@@ -1,28 +1,28 @@
 'use strict'
 
-const httpStatusCodes = require('http-status-codes');
+const { StatusCodes } = require('http-status-codes');
 const { httpErrorHandler } = require("../../common/handlers");
 const { deleteUserService } = require('../../services');
 
 const deleteUserHandler = async (req, res, next) => {
-    try{
+  try {
 
-        const {
-            user_id
-        } = req.query;
+    const {
+      user_id
+    } = req.query;
 
-        const {
-            deletedUser
-        } = await deleteUserService({
-            user_id
-        })
+    const {
+      deletedUser
+    } = await deleteUserService({
+      user_id
+    })
 
-        return res.status(httpStatusCodes.OK).send({deletedUser})
-    }catch(error){
-        return httpErrorHandler({ req, res, error })
-    }
+    return res.status(StatusCodes.OK).send({ deletedUser })
+  } catch (error) {
+    return httpErrorHandler({ req, res, error })
+  }
 }
 
 module.exports = {
-    deleteUserHandler
+  deleteUserHandler
 }

--- a/src/modules/handlers/User/listUsers.js
+++ b/src/modules/handlers/User/listUsers.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const httpStatusCodes = require('http-status-codes');
+const { StatusCodes } = require('http-status-codes');
 const { httpErrorHandler } = require('../../common/handlers');
 const {
   getUserByIdService,
@@ -25,7 +25,7 @@ const listUserHandler = async (req, res, next) => {
       ...users_response ? users_response.users : []
     ];
 
-    return res.status(httpStatusCodes.OK).send({ users });
+    return res.status(StatusCodes.OK).send({ users });
   } catch (error) {
     return httpErrorHandler({ req, res, error })
   }

--- a/src/modules/handlers/User/updateUser.js
+++ b/src/modules/handlers/User/updateUser.js
@@ -1,30 +1,30 @@
 'use strict'
-const httpStatusCodes = require('http-status-codes');
+const { StatusCodes } = require('http-status-codes');
 const { httpErrorHandler } = require("../../common/handlers");
 const { updateUserService } = require('../../services');
 
 const updateUserHandler = async (req, res, next) => {
-    try{
-        const {
-            id,
-            user_email,
-            user_password,
-            full_name
-        } = req.body
+  try {
+    const {
+      id,
+      user_email,
+      user_password,
+      full_name
+    } = req.body
 
-        const updated_user = await updateUserService({
-            id,
-            user_email,
-            user_password,
-            full_name
-        })
+    const updated_user = await updateUserService({
+      id,
+      user_email,
+      user_password,
+      full_name
+    })
 
-        return res.status(httpStatusCodes.OK).send(updated_user);
-    }catch(error){
-        return httpErrorHandler({ req, res, error })
-    }
+    return res.status(StatusCodes.OK).send(updated_user);
+  } catch (error) {
+    return httpErrorHandler({ req, res, error })
+  }
 }
 
 module.exports = {
-    updateUserHandler
+  updateUserHandler
 }


### PR DESCRIPTION
## Causa do problema
O método `httpStatusCodes` ficou depreciado na versão utilizada no projeto.

## Por que a alteração foi feita de tal maneira
Para evitar problemas com código não mentido pela biblioteca e para manter o projeto com código moderno e atualizado.

## Como a alteração resolve o problema encontrado
Ao usar o método `StatusCodes` com o status desejado, temos um código atualizado e não depreciado.
