### PR TITLE
Fix | Especifica qual post deve ser deletado

### DIFF
--- a/src/modules/repositories/Post/deletePostRepositories/deletePostRepositories.js
+++ b/src/modules/repositories/Post/deletePostRepositories/deletePostRepositories.js
@@ -1,25 +1,23 @@
 const {
-    getTransaction,
-    commitTransaction,
-    rollbackTransaction
+  getTransaction,
+  commitTransaction,
+  rollbackTransaction
 } = require('../../../common/handlers')
 
-const deletePostRepositories = async (
-    post_id
-) => {
-    const { transaction } = await getTransaction();
+const deletePostRepositories = async ({ post_id }) => {
+  const { transaction } = await getTransaction();
 
-    try {
-        await transaction('posts').del()
+  try {
+    await transaction('posts').where({ id: post_id }).del()
 
-        await commitTransaction({transaction})
-        
-    } catch (err) {
-        rollbackTransaction({transaction})
-        throw new Error(err)
-    }
+    await commitTransaction({ transaction })
+
+  } catch (err) {
+    rollbackTransaction({ transaction })
+    throw new Error(err)
+  }
 }
 
 module.exports = {
-    deletePostRepositories
+  deletePostRepositories
 }


### PR DESCRIPTION
## Causa do problema
Todos os posts estavam sendo deletado.

## Por que a alteração foi feita de tal maneira
Para deletar apenas um post especificado pelo id.

## Como a alteração resolve o problema encontrado
Ao especificar o post que deve ser deletado, utilizando o id do post e o método `where` do knex, apenas um post é deletado, ao invés de todos como era o comportamento antigo.
